### PR TITLE
Removed extra div that was showing up in textareas

### DIFF
--- a/public/js/greenhouse-job-board-public.js
+++ b/public/js/greenhouse-job-board-public.js
@@ -369,9 +369,6 @@
 				// back to simple fields 
 				else {
 					field_wrap += " />";
-					if ( !hidden ) {
-						field_wrap += "</div>";
-					}
 				}
 				$(jbid + " #apply_form").append(field_wrap);
 			}


### PR DESCRIPTION
VERSION:  2.7.3

This code was causing the string literal `</div>` to show up inside of input fields.  I manually commented out this line on my WP server, and things rendered as expected.

Before:
![image](https://user-images.githubusercontent.com/19597570/114409310-ef18ff00-9b6f-11eb-9284-cfc8ddf93242.png)

After:
![image](https://user-images.githubusercontent.com/19597570/114409493-1ff93400-9b70-11eb-84cb-eee13dfd42c9.png)
