### PR TITLE
change ajax sync setting to true

### DIFF
--- a/public/js/greenhouse-job-board-public.js
+++ b/public/js/greenhouse-job-board-public.js
@@ -536,7 +536,7 @@
 			    type: $(formid).attr('method'),
 			    url: $(formid).attr('action'),
 			    data: formData,
-			    async: false,
+			    async: true,
 		        cache: false,
 		        contentType: false,
 		        processData: false,


### PR DESCRIPTION
this fixes a problem where some times[1] on some browsers[2] the inline version of application forms would fail to submit because of a "failure to 'send ' on 'XMLHttpRequest'" and thus to load …/greenhouse-job-board-apply-submit.php


[1] unclear why, but this problem occurred on our production server but not our staging server
[2] browsers that failed included Chrome and Edge; browsers that worked even on our production server included Firefox and Safari